### PR TITLE
Add SetAll()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # maputil
-A go util package to assist working with map[string]interface{} types.
+A go util package to assist working with JSON that has been unmarshaled into map[string]interface{} and []interface{} types.
 
 License: MIT


### PR DESCRIPTION
Traverses all []interface{} and map[string]interface{} types, and runs the supplied function for each key/value pair.

This changes the scope of the library a little bit - previously it was intended for map[string]interface{} types, but as time has gone on it is clear that it needs to also support []interface{} types to achieve its goals (to improve the ability to work with unstructured JSON schemas).